### PR TITLE
Option to require authentication to access meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ You can email a meter report in code:
 
     MeterCat.mail
 
+### Require authentication
+
+Create or add to `config/initializers/meter_cat.rb`
+
+    MeterCat.configure do |config|
+      config.authenticate_with do
+        warden.authenticate! scope: :user
+      end
+    end
+
+### Require authorization
+
+Create or add to `config/initializers/meter_cat.rb`
+
+    MeterCat.configure do |config|
+      config.authorize_with do
+        redirect_to main_app.root_path unless current_user.try(:admin?)
+      end
+    end
+
 ## Reference
 
  * [Getting Started with Engines](http://edgeguides.rubyonrails.org/engines.html)

--- a/app/controllers/meter_cat/meters_controller.rb
+++ b/app/controllers/meter_cat/meters_controller.rb
@@ -2,6 +2,9 @@ module MeterCat
 
   class MetersController < ApplicationController
 
+    before_filter :_authenticate!
+    before_filter :_authorize!
+
     DEFAULT_DAYS = 7
 
     def index
@@ -27,6 +30,16 @@ module MeterCat
           render :text => Meter.to_csv( @range, @names ), :content_type => 'text/csv'
         end
       end
+    end
+
+    private
+
+    def _authenticate!
+      instance_eval(&MeterCat.config.authenticate_with)
+    end
+
+    def _authorize!
+      instance_eval(&MeterCat.config.authorize_with)
     end
 
   end

--- a/lib/meter_cat/config.rb
+++ b/lib/meter_cat/config.rb
@@ -5,6 +5,9 @@ module MeterCat
   class Config
     include Singleton
 
+    DEFAULT_AUTHENTICATION = proc {}
+    DEFAULT_AUTHORIZE = proc {}
+
     attr_accessor :calculator, :expiration, :retry_attempts, :retry_delay
     attr_accessor :from, :mail_days, :mail_names, :subject, :to
 
@@ -25,6 +28,16 @@ module MeterCat
 
     def sum( name, values )
       @calculator.sum( name, values )
+    end
+
+    def authenticate_with(&blk)
+      @authenticate = blk if blk
+      @authenticate || DEFAULT_AUTHENTICATION
+    end
+
+    def authorize_with(&block)
+      @authorize = block if block
+      @authorize || DEFAULT_AUTHORIZE
     end
 
   end

--- a/spec/controllers/meter_cat/meters_controller_spec.rb
+++ b/spec/controllers/meter_cat/meters_controller_spec.rb
@@ -38,6 +38,12 @@ describe MeterCat::MetersController do
       expect( assigns( :all_names ) ).to be_present
     end
 
+    it 'uses the configured before authentication filter' do
+      expect( @controller ).to receive( :instance_eval ).with( &MeterCat.config.authenticate_with )
+      expect( @controller ).to receive( :instance_eval ).with( &MeterCat.config.authorize_with )
+      get :index
+    end
+
     context 'formatting CSV' do
 
       it 'converts meters to CSV' do


### PR DESCRIPTION
_Credit: This implementation copied directly from the [rails_admin engine](https://github.com/sferik/rails_admin)_

Add a configuration option to authenticate users who want to view meters

**TODO**

I was unable to run the tests because there is a problem setting up the test db:

```
> RAILS_ENV=test bundle exec rake db:migrate
rake aborted!
Multiple migrations have the name CreateMeterCatMeters
```
